### PR TITLE
fix billing link

### DIFF
--- a/src/cron/index.ts
+++ b/src/cron/index.ts
@@ -33,7 +33,7 @@ cron.schedule("0 12 * * *", async () => {
             trialEndsAt: trial.trialEnd.toISOString(),
             daysRemaining: daysAhead,
             upgradeUrl: process.env.FRONTEND_URL
-              ? `${process.env.FRONTEND_URL}/billing`
+              ? `${process.env.FRONTEND_URL}/settings/subscription`
               : undefined,
           });
         } catch (perTrialError) {

--- a/src/services/StripeService.ts
+++ b/src/services/StripeService.ts
@@ -152,7 +152,7 @@ export class StripeService {
         ? new Date(invoice.next_payment_attempt * 1000).toISOString()
         : undefined,
       updatePaymentUrl: process.env.FRONTEND_URL
-        ? `${process.env.FRONTEND_URL}/billing`
+        ? `${process.env.FRONTEND_URL}/settings/subscription`
         : undefined,
     }).catch(() => {
       /* unreachable — client swallows internally; defense-in-depth only */


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
Updates billing-related links to direct users to the new subscription management page.

Specifically, this change:
- Modifies the `upgradeUrl` in trial-end notifications (sent via cron job) from `/billing` to `/settings/subscription`.
- Updates the `updatePaymentUrl` generated by the Stripe service from `/billing` to `/settings/subscription`.

This ensures that all relevant links point to the correct frontend path for managing subscriptions and payment information.
<!-- kody-pr-summary:end -->