### PR TITLE
fix(build): unbreak tsc so the trial-credits image ships to QA

### DIFF
--- a/src/controllers/SubscriptionController.ts
+++ b/src/controllers/SubscriptionController.ts
@@ -336,8 +336,8 @@ export class SubscriptionController {
             }
 
             const url = await StripeService.createCustomerPortalSession(
-                organizationId,
-                teamId,
+                organizationId as string,
+                teamId as string,
             );
 
             return res.json({ url });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,5 @@
 import "reflect-metadata"; // Importante para TypeORM
 import express, { Express } from "express";
-import bodyParser from "body-parser";
 import helmet from "helmet";
 import cors from "cors";
 import { initializeDatabase, AppDataSource } from "./config/database";
@@ -39,8 +38,8 @@ app.use((req, res, next) => {
   }
 });
 
-app.use(bodyParser.urlencoded({ extended: false }));
-app.use(bodyParser.json({ limit: "10mb" }));
+app.use(express.urlencoded({ extended: false }));
+app.use(express.json({ limit: "10mb" }));
 
 registerApiDocs(app);
 

--- a/src/routes/subscription.routes.ts
+++ b/src/routes/subscription.routes.ts
@@ -3,7 +3,7 @@ import express from "express";
 import { SubscriptionController } from "../controllers/SubscriptionController";
 import { cacheMiddleware } from "../middlewares/cacheMiddleware";
 
-const router = Router();
+const router: Router = Router();
 
 /**
  * @openapi


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request fixes TypeScript compilation errors (`tsc`) that were preventing the build pipeline from producing the trial-credits image for QA deployment.

The changes resolve strict typing issues and remove an unnecessary external dependency:

- **Subscription controller**: Added explicit `as string` type assertions to the `organizationId` and `teamId` arguments passed to `StripeService.createCustomerPortalSession` to satisfy type requirements.
- **Application bootstrap (`index.ts`)**: Removed the external `body-parser` import and replaced `bodyParser.urlencoded()` and `bodyParser.json()` with Express's built-in `express.urlencoded()` and `express.json()` middleware.
- **Subscription routes**: Added an explicit `Router` type annotation to the router instance to resolve type inference errors.

Together, these corrections unbreak the TypeScript toolchain and restore the ability to build and ship the service image to QA.
<!-- kody-pr-summary:end -->